### PR TITLE
When doing "Send Device Authenticator request", you can hang the system

### DIFF
--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -35,10 +35,6 @@ config NCE_SDK_MAX_STRING_SIZE
 	int "Max string size in the payload before conversion"
 	default 50
 
-config NCE_SDK_SEND_TIMEOUT_SECS
-    int "Max number of seconds to wait for a send to succeed"
-    default 60
-
 config NCE_SDK_RECEIVE_TIMEOUT_SECS
     int "Max number of seconds to wait for a response"
     default 60

--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -34,7 +34,15 @@ config NCE_SDK_ATTEMPTS
 config NCE_SDK_MAX_STRING_SIZE
 	int "Max string size in the payload before conversion"
 	default 50
-	
+
+config NCE_SDK_SEND_TIMEOUT_SECS
+    int "Max number of seconds to wait for a send to succeed"
+    default 60
+
+config NCE_SDK_RECEIVE_TIMEOUT_SECS
+    int "Max number of seconds to wait for a response"
+    default 60
+
 
 module = NCE_SDK
 module-str = NCE_SDK

--- a/ports/zephyr/udp_interface_zephyr.c
+++ b/ports/zephyr/udp_interface_zephyr.c
@@ -45,12 +45,6 @@ int nce_os_udp_connect( OSNetwork_t osnetwork,
         NceOSLogError("Failed to set receive timeout: %d\n", err);
         return err;
     }
-    timeout.tv_sec  = CONFIG_NCE_SDK_SEND_TIMEOUT_SECS;
-    err = zsock_setsockopt(socket, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
-    if (err < 0) {
-        NceOSLogError("Failed to set send timeout: %d\n", err);
-        return err;
-    }
 
     /* Set SO_REUSEADDR option */
     const int reuse = 1;

--- a/ports/zephyr/udp_interface_zephyr.c
+++ b/ports/zephyr/udp_interface_zephyr.c
@@ -28,7 +28,6 @@ int nce_os_udp_connect( OSNetwork_t osnetwork,
 {
     int socket = zsock_socket( AF_INET, SOCK_DGRAM,
                                IPPROTO_UDP );
-    int err;
     struct zsock_addrinfo * addr;
     struct zsock_addrinfo hints =
     {
@@ -36,10 +35,39 @@ int nce_os_udp_connect( OSNetwork_t osnetwork,
         .ai_socktype = SOCK_DGRAM
     };
 
-    err = zsock_getaddrinfo ( nce_oboarding.host,
-                              NULL, &hints, &addr );
+    /* Set socket timeouts */
+    struct timeval timeout;
+    timeout.tv_sec  = CONFIG_NCE_SDK_RECEIVE_TIMEOUT_SECS;
+    timeout.tv_usec = 0;
 
-    NceOSLogDebug( "getaddrinfo status: %d\n", err );
+    int err = zsock_setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    if (err < 0) {
+        NceOSLogError("Failed to set receive timeout: %d\n", err);
+        return err;
+    }
+    timeout.tv_sec  = CONFIG_NCE_SDK_SEND_TIMEOUT_SECS;
+    err = zsock_setsockopt(socket, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+    if (err < 0) {
+        NceOSLogError("Failed to set send timeout: %d\n", err);
+        return err;
+    }
+
+    /* Set SO_REUSEADDR option */
+    const int reuse = 1;
+    err = zsock_setsockopt(socket, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+    if (err < 0) {
+        NceOSLogError("Failed to set reuse addr: %d\n", err);
+        return err;
+    }
+
+
+    err = zsock_getaddrinfo( nce_oboarding.host,
+                       NULL, &hints, &addr );
+
+    if (err < 0) {
+        NceOSLogError("Failed to get addr info: %d\n", err);
+        return err;
+    }
 
     osnetwork->os_socket = socket;
 

--- a/source/nce_iot_c_sdk.c
+++ b/source/nce_iot_c_sdk.c
@@ -109,7 +109,7 @@ static int _get_psk( char * packet,
             strcpy( nceKey->Psk, p );
         }
 
-        NceOSLogInfo( "DTLS Credentials Recieved.\n" );
+        NceOSLogInfo( "DTLS Credentials Received.\n" );
         return NCE_SDK_SUCCESS;
     }
 }

--- a/source/nce_iot_c_sdk.c
+++ b/source/nce_iot_c_sdk.c
@@ -46,7 +46,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <udp_interface_zephyr.h>
-#include <zephyr/net/socket.h> //for testing only, remove LUC
 
 #ifdef __ZEPHYR__
 LOG_MODULE_REGISTER( NCE_SDK, CONFIG_NCE_SDK_LOG_LEVEL );
@@ -208,28 +207,7 @@ static int _os_coap_onboard( os_network_ops_t * osNetwork,
     memset( pBuffer, '\0', bufferSize * sizeof( char ) );
     sprintf( pBuffer, "%.2s%.2s%.2s%s%.1sbootstrap", coap_header, message_id_str, uri_host_option, NceOnboard.host, uri_path_option );
     NceOSLogInfo( "Send Device Authenticator request.\n" );
-    //for testing only
-    /* Set socket timeouts */
-    struct timeval timeout;
-    static int counter = 1;
-
-    if (counter < 6)
-    {
-        timeout.tv_sec  = 0;
-        timeout.tv_usec = 100;
-        counter++;
-    } else {
-        timeout.tv_sec  = CONFIG_NCE_SDK_RECEIVE_TIMEOUT_SECS;
-        timeout.tv_usec = 0;
-    }
-    int err = zsock_setsockopt(osNetwork->os_socket->os_socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
-    if (err < 0) {
-        NceOSLogError("Failed to set receive timeout: %d\n", err);
-        return err;
-    }
-    //end testing
     status = osNetwork->nce_os_udp_send( osNetwork->os_socket, pBuffer, strlen( pBuffer ) );
-
     if( status < 0 )
     {
         NceOSLogError( "Failed to send Device Authenticator request, status %d\n", status );
@@ -239,7 +217,6 @@ static int _os_coap_onboard( os_network_ops_t * osNetwork,
     {
         memset( pBuffer, '\0', bufferSize * sizeof( char ) );
         status = osNetwork->nce_os_udp_recv( osNetwork->os_socket, pBuffer, bufferSize );
-
         if( status < 0 )
         {
             NceOSLogError( "Failed to receive Device credential, status %d\n", status);


### PR DESCRIPTION
When doing "Send Device Authenticator request" you will be waiting for a response which could never come.

This will hang the system. With this PR we add a Receive Timeout when we setup the socket. This way the connection will timeout and calling functions can deal with that.